### PR TITLE
refactor: minor cleanups

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
   "types": "environment.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start:prod": "node dist/index.js",
+    "start:prod": "node --require dotenv/config dist/index.js",
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
     "build": "tsc --pretty",
     "watch": "tsc -w",
     "start": "npm run build && npm run start:prod",
-    "deploy": "npm run build && node dist/deploy-commands.js"
+    "deploy": "npm run build && node --require dotenv/config dist/deploy-commands.js"
   },
   "repository": {
     "type": "git",

--- a/src/deploy-commands.ts
+++ b/src/deploy-commands.ts
@@ -13,7 +13,6 @@ import { join } from 'node:path';
 import { dynamicImport } from './misc/util.js';
 
 import type { Command } from './structures/command.js';
-import 'dotenv/config';
 
 const commands: RESTPostAPIApplicationCommandsJSONBody[] | RESTPostAPIApplicationGuildCommandsJSONBody[] = [];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 import { ExtendedClient } from './structures/client.js';
-import 'dotenv/config';
 
 const client = new ExtendedClient();
 client.start();

--- a/src/structures/command.ts
+++ b/src/structures/command.ts
@@ -27,6 +27,9 @@ interface CustomOptions {
     guildOnly?: boolean;
 };
 
+/**
+ * Defines the structure of an command.
+ */
 export type Command = {
     /**
      * The data for the command

--- a/src/structures/event.ts
+++ b/src/structures/event.ts
@@ -16,7 +16,7 @@ export type Event<Key extends keyof ClientEvents = keyof ClientEvents> = {
     once?: boolean;
     /**
      * The function to execute when the event is emitted.
-     * @param args - The parameters of the event
+     * @param parameters - The parameters of the event
      */
-    execute(...args: ClientEvents[Key]): Promise<void> | void;
+    execute(...parameters: ClientEvents[Key]): Promise<void> | void;
 };


### PR DESCRIPTION
- Require dotenv in script execution instead of importing.
- Rename args to parameters for event type.
- Add missing description for command type.