### PR TITLE
refactor: removing options & adjusted ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Features include:
 - Command & Event handler
 - A sample slash command & context menu command to get you started
 - Command cooldowns, user & client permission checks
-- Guild-only option (commands can be used only in guilds)
 
 ## Getting Started 🎉
 

--- a/src/commands/context/echo.ts
+++ b/src/commands/context/echo.ts
@@ -13,9 +13,7 @@ export default {
         userPermissions: ['SendMessages'],
         botPermissions: ['SendMessages'],
         category: 'Context',
-        cooldown: 5,
-        visible: true,
-        guildOnly: false
+        cooldown: 5
     },
     async execute(interaction: MessageContextMenuCommandInteraction<'cached'>) {
         const message = await interaction.targetMessage.fetch();

--- a/src/commands/general/ping.ts
+++ b/src/commands/general/ping.ts
@@ -11,9 +11,7 @@ export default {
         userPermissions: ['SendMessages'],
         botPermissions: ['SendMessages'],
         category: 'General',
-        cooldown: 5,
-        visible: true,
-        guildOnly: false
+        cooldown: 5
     },
     async execute(interaction: ChatInputCommandInteraction<'cached'>) {
         const currentTime = 1000 * 75 - interaction.client.uptime;

--- a/src/commands/general/ping.ts
+++ b/src/commands/general/ping.ts
@@ -2,6 +2,8 @@ import { type ChatInputCommandInteraction, inlineCode, RESTJSONErrorCodes, time,
 
 import type { Command } from '../../structures/command.js';
 
+import wait from 'node:timers/promises';
+
 export default {
     data: {
         name: 'ping',
@@ -31,16 +33,18 @@ export default {
             fetchReply: true
         });
 
-        setTimeout(async () => {
+        try {
+            await wait.setTimeout(3000);
+
             const ping = msg.createdTimestamp - interaction.createdTimestamp;
+
             await interaction.editReply({
                 content: `Pong 🏓! \nRoundtrip Latency is ${inlineCode(`${ping}ms`)}. \nWebsocket Heartbeat is ${inlineCode(`${interaction.client.ws.ping}ms`)}`
-            }).catch((err) => {
-                if (err.code === RESTJSONErrorCodes.UnknownMessage) {
-                    console.error(`Failed to edit interaction: ${err.message}`);
-                }
-            });
-            return;
-        }, 3_000);
+            })
+        } catch (error) {
+            if (error.code === RESTJSONErrorCodes.UnknownMessage) {
+                console.error(`Failed to edit interaction: ${error.message}`);
+            }
+        }
     }
 } satisfies Command;

--- a/src/events/interaction/command.ts
+++ b/src/events/interaction/command.ts
@@ -21,14 +21,6 @@ export default {
             return;
         };
 
-        if (command.opt?.guildOnly && interaction.channel.isDMBased()) {
-            await interaction.reply({
-                content: '⚠️ This command can only be used in a guild.',
-                ephemeral: true
-            });
-            return;
-        };
-
         if (command.opt?.userPermissions) {
             const missingUserPerms = missingPerms(interaction.member.permissionsIn(interaction.channel), command.opt?.userPermissions) ?
                 missingPerms(interaction.member.permissionsIn(interaction.channel), command.opt?.userPermissions) :

--- a/src/structures/command.ts
+++ b/src/structures/command.ts
@@ -17,14 +17,6 @@ interface CustomOptions {
      * The cooldown of the command in seconds
      */
     cooldown?: number;
-    /**
-     * Whether the command is hidden from the help command
-     */
-    visible?: boolean;
-    /**
-     * Whether the command can only be used in guilds
-     */
-    guildOnly?: boolean;
 };
 
 /**


### PR DESCRIPTION
- Removed `guildOnly` option since `dm_permission` can be used to prevent the command from being ran inside a DM.
- The `visible` option really was meant for hiding specific commands shown in a help command, which was never added to this project.
- The **ping command** was adjusted to use a promise-based setTimeout instead of an asynchronous callback in the native setTimeout.