### PR TITLE
chore: switch to node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Features include (but not limited to):
 - Optional per-command cooldowns & User / Client permission checking
 
 > [!IMPORTANT]
-> **Most current [Node LTS (Long-Term Support) Version](https://nodejs.org) is required**
+> **The latest [Node LTS (Long-Term Support) Version](https://nodejs.org) is required**
 
 ## Getting Started 🎉
 

--- a/package.json
+++ b/package.json
@@ -9,27 +9,25 @@
     "build": "tsc --pretty",
     "clean": "rimraf dist",
     "dev": "pnpm build && pnpm start",
-    "deploy": "pnpm build && node --require dotenv/config dist/deploy-commands.js",
+    "deploy": "pnpm build && node --env-file=.env dist/deploy-commands.js",
     "prebuild": "pnpm run clean",
-    "start": "pnpm run build && node --require dotenv/config dist/index.js",
+    "start": "pnpm run build && node --env-file=.env dist/index.js",
     "watch": "tsc -w"
   },
   "dependencies": {
-    "chalk": "^5.3.0",
-    "discord.js": "^14.16.2",
-    "dotenv": "^16.4.5"
+    "discord.js": "^14.16.2"
   },
   "devDependencies": {
     "rimraf": "^6.0.1",
     "typescript": "^5.6.2"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=20",
     "pnpm": "9.10.0"
   },
   "packageManager": "pnpm@9.10.0",
   "volta": {
-    "node": "18.17.0",
+    "node": "20.17.0",
     "pnpm": "9.10.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,9 @@ importers:
 
   .:
     dependencies:
-      chalk:
-        specifier: ^5.3.0
-        version: 5.3.0
       discord.js:
         specifier: ^14.16.2
         version: 14.16.2
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.4.5
     devDependencies:
       rimraf:
         specifier: ^6.0.1
@@ -107,10 +101,6 @@ packages:
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
-  chalk@5.3.0:
-    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -131,10 +121,6 @@ packages:
   discord.js@14.16.2:
     resolution: {integrity: sha512-VGNi9WE2dZIxYM8/r/iatQQ+3LT8STW4hhczJOwm+DBeHq66vsKDCk8trChNCB01sMO9crslYuEMeZl2d7r3xw==}
     engines: {node: '>=18'}
-
-  dotenv@16.4.5:
-    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
-    engines: {node: '>=12'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -372,8 +358,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  chalk@5.3.0: {}
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -407,8 +391,6 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-
-  dotenv@16.4.5: {}
 
   eastasianwidth@0.2.0: {}
 


### PR DESCRIPTION
- Changes the Node version to 20.
- Removes the `dotenv` package in favor of Node built-in [env support](https://nodejs.org/dist/latest-v20.x/docs/api/cli.html#--env-fileconfig).
- Removes the unnecessary `chalk` package.