### PR TITLE
Fix and check typed imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Features include (not limited to):
 4. Install dependencies.
 
    ```bash
-   pnpm install
+   npm install
    ```
 
 5. Deploy commands.
 
    ```bash
-   pnpm run deploy
+   npm run deploy
    ```
 
 > [!NOTE]
@@ -63,7 +63,7 @@ Features include (not limited to):
 6. Starting the bot
 
    ```bash
-   pnpm run start
+   npm run start
    ```
 
 ## Sample Commands 🤖

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,6 +33,7 @@ export default tseslint.config(
       "@typescript-eslint/no-floating-promises": 1,
       "@typescript-eslint/no-unused-vars": 1,
       "@typescript-eslint/prefer-optional-chain": 1,
+      "@typescript-eslint/consistent-type-imports": 2,
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
         "discord.js": "^14.21.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.30.0",
-        "@types/node": "^24.0.8",
-        "eslint": "^9.30.0",
-        "globals": "^16.2.0",
+        "@eslint/js": "^9.30.1",
+        "@types/node": "^24.0.10",
+        "eslint": "^9.30.1",
+        "globals": "^16.3.0",
         "prettier": "^3.6.2",
         "rimraf": "^6.0.1",
         "typescript": "^5.8.3",
@@ -272,9 +272,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.0.tgz",
-      "integrity": "sha512-Wzw3wQwPvc9sHM+NjakWTcPx11mbZyiYHuwWa/QfZ7cIRX7WK54PSk7bdyXDaoaopUcMatv1zaQvOAAO8hCdww==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
+      "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -543,9 +543,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.8.tgz",
-      "integrity": "sha512-WytNrFSgWO/esSH9NbpWUfTMGQwCGIKfCmNlmFDNiI5gGhgMmEA+V1AEvKLeBNvvtBnailJtkrEa2OIISwrVAA==",
+      "version": "24.0.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.10.tgz",
+      "integrity": "sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -1081,9 +1081,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.30.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.0.tgz",
-      "integrity": "sha512-iN/SiPxmQu6EVkf+m1qpBxzUhE12YqFLOSySuOyVLJLEF9nzTf+h/1AJYc1JWzCnktggeNrjvQGLngDzXirU6g==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
+      "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1093,7 +1093,7 @@
         "@eslint/config-helpers": "^0.3.0",
         "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.30.0",
+        "@eslint/js": "9.30.1",
         "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -1463,9 +1463,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.2.0.tgz",
-      "integrity": "sha512-O+7l9tPdHCU320IigZZPj5zmRCFG9xHmx9cU8FqU2Rp+JN714seHV+2S9+JslCpY4gJwU2vOGox0wzgae/MCEg==",
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
+      "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "discord.js": "^14.21.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.30.0",
-    "@types/node": "^24.0.8",
-    "eslint": "^9.30.0",
-    "globals": "^16.2.0",
+    "@eslint/js": "^9.30.1",
+    "@types/node": "^24.0.10",
+    "eslint": "^9.30.1",
+    "globals": "^16.3.0",
     "prettier": "^3.6.2",
     "rimraf": "^6.0.1",
     "typescript": "^5.8.3",

--- a/src/misc/util.ts
+++ b/src/misc/util.ts
@@ -10,7 +10,7 @@ import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import type { Command } from "../structures/command.js";
-import { Event } from "../structures/event.js";
+import type { Event } from "../structures/event.js";
 
 /**
  * This function gets the default export from a file.


### PR DESCRIPTION
This PR ensures that imports that are primarily used for types should be marked as `type` when being imported. One file was modified to ensure this behavior. In addition to this, a TypeScript ESLint rule was added to encourage the user is aware of correctly importing types, indicated by the `type` keyword, when needed, promoting an error when needing necessary changes.

Moreover, all required dependencies have been updated, and a slight fix in the README ensured that `npm` was being used instead of `pnpm`, as most scripts within package.json use the same keyword. This can be modified later on by the user if needed.